### PR TITLE
move from `created` to `released` trigger for release workflow

### DIFF
--- a/src/django_twc_package/.github/workflows/release.yml.jinja
+++ b/src/django_twc_package/.github/workflows/release.yml.jinja
@@ -2,7 +2,7 @@ name: release
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   check:


### PR DESCRIPTION
closes #49 